### PR TITLE
Use render, rather than render_to_response

### DIFF
--- a/rapidsms/views.py
+++ b/rapidsms/views.py
@@ -4,17 +4,16 @@
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth.views import login as django_login
 from django.contrib.auth.views import logout as django_logout
-from django.shortcuts import render_to_response
+from django.shortcuts import render
 from django.template import RequestContext
 from django.views.decorators.http import require_GET
 
 
 @login_required
 @require_GET
-def dashboard(req):
-    return render_to_response(
-        "dashboard.html",
-        context_instance=RequestContext(req))
+def dashboard(request):
+    return render(request,
+        "dashboard.html")
 
 
 def login(req, template_name="rapidsms/login.html"):


### PR DESCRIPTION
This PR uses the more up-to-date `render` function for Django 1.11: https://docs.djangoproject.com/en/1.11/topics/http/shortcuts/#render-to-response